### PR TITLE
Fixing a stupid bug introduced by #1; Added some more unit test

### DIFF
--- a/src/main/java/org/cogcomp/nlp/cooccurrence/core/ImmutableTermDocMatrix.java
+++ b/src/main/java/org/cogcomp/nlp/cooccurrence/core/ImmutableTermDocMatrix.java
@@ -121,8 +121,8 @@ public class ImmutableTermDocMatrix {
      */
     public int getTermCountInDoc(String term, String doc) {
         int termId = lex.putOrGet(term);
-        int docId = lex.putOrGet(doc);
-        if (termId >= this.lexSize || docId >= this.lexSize)
+        int docId = docid.putOrGet(doc);
+        if (termId >= this.lexSize || docId >= this.docCount)
             return 0;
         else
             return (int)_getDocwiseTermCount(termId, docId);

--- a/src/main/java/org/cogcomp/nlp/cooccurrence/core/ImmutableTermTermMatrix.java
+++ b/src/main/java/org/cogcomp/nlp/cooccurrence/core/ImmutableTermTermMatrix.java
@@ -23,7 +23,6 @@ public class ImmutableTermTermMatrix {
     ImmutableTermTermMatrix(ImmutableTermDocMatrix tdmat) {
         this.lex = tdmat.getLexicon();
         this.coocMat = tdmat.tdMat.multiplyByItsTranspose();
-        System.out.println(coocMat.getClass().getCanonicalName());
     }
 
     public int getCoocCount(String term1, String term2) {

--- a/src/test/java/TermDocMatTest.java
+++ b/src/test/java/TermDocMatTest.java
@@ -52,11 +52,9 @@ public class TermDocMatTest {
         assertEquals(lex.size(), mat.getNumTerm());
         assertEquals(mat.getTermTotalCount(word), 12);
         assertEquals(mat.getTermTotalCount("Gibberish"), 0);
-        assertEquals(mat.getTermCountInDoc("Gibberish", "1121146.txt"),0);
-        assertEquals(mat.getTermCountInDoc("this", "1121146.txt"),3);
+        assertEquals(mat.getTermCountInDoc("Gibberish", "1121146"),0);
+        assertEquals(mat.getTermCountInDoc(word, "1121146"),3);
         proc.close();
-
-        ImmutableTermTermMatrix cooc = CoocMatrixFactory.createCoocMatrixFromTermDocMatrix(mat);
     }
 
     @Test

--- a/src/test/java/TermDocMatTest.java
+++ b/src/test/java/TermDocMatTest.java
@@ -53,6 +53,7 @@ public class TermDocMatTest {
         assertEquals(mat.getTermTotalCount(word), 12);
         assertEquals(mat.getTermTotalCount("Gibberish"), 0);
         assertEquals(mat.getTermCountInDoc("Gibberish", "1121146.txt"),0);
+        assertEquals(mat.getTermCountInDoc("this", "1121146.txt"),3);
         proc.close();
 
         ImmutableTermTermMatrix cooc = CoocMatrixFactory.createCoocMatrixFromTermDocMatrix(mat);


### PR DESCRIPTION
In #1 , I made a stupid [mistake](https://github.com/schen149/Cooccurrence/blob/d0fcbd9f53899fec523b939f071d7ecd4882aaaa/src/main/java/org/cogcomp/nlp/cooccurrence/core/ImmutableTermDocMatrix.java#L124-126) .